### PR TITLE
Removed 1 unnecessary stubbings in OpmlParserInputTest.java

### DIFF
--- a/src/test/java/be/ceau/opml/OpmlParserInputTest.java
+++ b/src/test/java/be/ceau/opml/OpmlParserInputTest.java
@@ -26,7 +26,6 @@ public class OpmlParserInputTest {
 	@Test(expected = OpmlParseException.class)
 	public void ioException() throws IOException, OpmlParseException {
 		InputStream inputStream = Mockito.mock(InputStream.class);
-		Mockito.when(inputStream.read(new byte[0])).thenThrow(IOException.class);
 		new OpmlParser().parse(inputStream);
 	}
 	


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 1 unnecessary stubbing in `OpmlParserInputTest.ioException` is created but never executed.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.